### PR TITLE
pdf: implement outrotate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ FDIR = /neatroff/font
 
 CC = cc
 CFLAGS = -Wall -O2 "-DTROFFFDIR=\"$(FDIR)\""
-LDFLAGS =
+LDFLAGS = -lm
 OBJS = post.o ps.o font.o dev.o clr.o dict.o iset.o sbuf.o
 OBJSPDF = post.o pdf.o pdfext.o font.o dev.o clr.o dict.o iset.o sbuf.o
 

--- a/post.c
+++ b/post.c
@@ -289,7 +289,7 @@ static void postps(void)
 	if (!strcmp("PS", cmd) || !strcmp("ps", cmd))
 		out("%s\n", arg);
 	if (!strcmp("rotate", cmd))
-		outrotate(atoi(arg));
+		outrotate(atof(arg));
 	if (!strcmp("eps", cmd) || !strcmp("pdf", cmd)) {
 		char path[1 << 12];
 		int hwid, vwid, nspec;

--- a/post.h
+++ b/post.h
@@ -56,7 +56,7 @@ void outrel(int h, int v);
 void outfont(int f);
 void outsize(int s);
 void outcolor(int c);
-void outrotate(int deg);
+void outrotate(double deg);
 void outeps(char *eps, int hwid, int vwid);
 void outpdf(char *pdf, int hwid, int vwid);
 void outlink(char *dst, int hwid, int vwid);

--- a/ps.c
+++ b/ps.c
@@ -13,7 +13,8 @@ static int o_h, o_v;		/* current user position */
 static int p_f, p_s, p_m;	/* output postscript font */
 static int o_qtype;		/* queued character type */
 static int o_qv, o_qh, o_qend;	/* queued character position */
-static int o_rh, o_rv, o_rdeg;	/* previous rotation position and degree */
+static int o_rh, o_rv;
+static double o_rdeg;		/* previous rotation position and degree */
 static int o_gname;		/* use glyphshow for all glyphs */
 
 static char o_fonts[FNLEN * NFONTS] = " ";
@@ -161,16 +162,16 @@ void outcolor(int c)
 	o_m = c;
 }
 
-void outrotate(int deg)
+void outrotate(double deg)
 {
 	o_flush();
 	out_fontup(o_f);
 	if (o_rdeg)
-		outf("%d %d %d rot\n", -o_rdeg, o_rh, o_rv);
+		outf("%f %d %d rot\n", -o_rdeg, o_rh, o_rv);
 	o_rdeg = deg;
 	o_rh = o_h;
 	o_rv = o_v;
-	outf("%d %d %d rot\n", deg, o_h, o_v);
+	outf("%f %d %d rot\n", deg, o_h, o_v);
 }
 
 static int draw_path;	/* number of path segments */


### PR DESCRIPTION
This requires the current transformation matrix to be modified (with the 'cm' operator'), and that
uses trigonometric functions (which requires to be linked with -lm). Since it changes the graphic context we must now store it and then restore it, so 'q' before 'BT' and 'Q' after 'ET' (as equivalents to gsave
and grestore).

In PostScript, 'rotate' does more than just rotating like what we do with 'cm': it also affects the
whole page. To achieve this in PDF we use the
/Rotate field in the /Page object.

The rotate degree was also changed to a double to
allow greater precision. This affects post, ps,
and pdf.