### PR TITLE
pdf&ps: Add support for line control

### DIFF
--- a/pdf.c
+++ b/pdf.c
@@ -879,8 +879,8 @@ void drawend(int close, int fill)
 	fill = !fill ? 2 : fill;
 	if (l_page != page_n || l_size != o_s || l_wid != pdf_linewid ||
 			l_cap != pdf_linecap || l_join != pdf_linejoin) {
-		int lwid = pdf_linewid * o_s;
-		sbuf_printf(pg, "%d.%03d w\n", lwid / 1000, lwid % 1000);
+		int lwid = pdf_linewid;
+		sbuf_printf(pg, "%d.%02d w\n", lwid / 100, lwid % 100);
 		sbuf_printf(pg, "%d J %d j\n", pdf_linecap, pdf_linejoin);
 		l_page = page_n;
 		l_size = o_s;
@@ -977,6 +977,11 @@ void draws(int h1, int v1, int h2, int v2)
 	sbuf_printf(pg, "%s c\n", pdfpos((x1 + x2) / 2, (y1 + y2) / 2));
 
 	outrel(h1, v1);
+}
+
+void drawt(int w)
+{
+	pdf_linewid = w * 7200 / dev_res;
 }
 
 void docheader(char *title, int pagewidth, int pageheight, int linewidth)

--- a/post.c
+++ b/post.c
@@ -232,6 +232,9 @@ static void postdraw(void)
 	int c = next();
 	drawbeg();
 	switch (tolower(c)) {
+	case 't':
+		drawt(nextnum());
+		break;
 	case 'l':
 		h1 = nextnum();
 		v1 = nextnum();

--- a/post.h
+++ b/post.h
@@ -77,6 +77,7 @@ void drawc(int c);
 void drawe(int h, int v);
 void drawa(int h1, int v1, int h2, int v2);
 void draws(int h1, int v1, int h2, int v2);
+void drawt(int w);
 
 void docheader(char *title, int pagewidth, int pageheight, int linewidth);
 void doctrailer(int pages);


### PR DESCRIPTION
This includes line thickness, line cap and line
join. This was added to ps using \X'set' commands.

A new drawing primitive, mirroring groff's, was
introduced: \D't'. It allows directly setting line
width using units. \D't 1i' has expected results
(a line width of an inch), whereas

.nr a 1i
.dv set linewidth \na

does not, because the argument of linewidth is in
thousandths of ems. It's also arguably more
cumbersome.